### PR TITLE
chore:  add default type axios-http-client.ejs

### DIFF
--- a/src/templates/base/http-clients/axios-http-client.ejs
+++ b/src/templates/base/http-clients/axios-http-client.ejs
@@ -97,7 +97,7 @@ export class HttpClient<SecurityDataType = unknown> {
     public request = async <T = any, _E = any>({
         secure,
         path,
-        type,
+        type = "application/json",
         query,
         format,
         body,


### PR DESCRIPTION
Description

By using the following payload: 
```ts
    return await sp.productFees.getMyFeesEstimateForAsin(asin, {
      FeesEstimateRequest: {
        MarketplaceId,
        IsAmazonFulfilled: true,
        PriceToEstimateFees: {
          ListingPrice: {
            CurrencyCode,
            Amount: 67.95,
          },
        },
        Identifier: crypto.randomUUID(),
      },
    });
```
I get the following response: 

```js
{
  errors: [
    {
      code: 'InvalidInput',
      message: 'Invalid Input',
      details: 'Content type must be set to application/json; charset=utf-8.'
    }
  ]
}
```



By adding this in the transpiled code: 
 ```diff
 class HttpClient {
    constructor(_a = {}) {
        var { securityWorker, secure, format } = _a, axiosConfig = __rest(_a, ["securityWorker", "secure", "format"]);
        this.securityData = null;
        this.setSecurityData = (data) => {
            this.securityData = data;
        };
        this.request = (_b) => __awaiter(this, void 0, void 0, function* () {
        var { secure, path, type 
+++= "application/json"
, query, format, body, code } = _b, params = __rest(_b, ["secure", "path", "type", "query", "format", "body", "code"]);
            const secureParams = ((typeof secure === "boolean" ? secure : this.secure) &&
 ```
 
 
 I get the correct response: 
```js
 {
  TotalFeesEstimate: { CurrencyCode: 'EUR', Amount: 20.39 },
  FeeDetailList: [
    {
      FeeType: 'ReferralFee',
      FeeAmount: [Object],
      FinalFee: [Object],
      FeePromotion: [Object]
    },
    {

```
